### PR TITLE
use filepath for cross-platform support

### DIFF
--- a/src/ui/interface.go
+++ b/src/ui/interface.go
@@ -6,14 +6,17 @@ import (
     "bufio"
     "fmt"
     "os"
+    "path/filepath"
 
     "github.com/jxd1337/gohard/src/mods"
     "github.com/jxd1337/gohard/src/util"
 )
 
 func Run(modules []mods.Module) {
+    assetPath := filepath.Join("assets", "modules.json")
+
     // Check for .json file, which contains hardening modules
-    assetExists, err := util.PathExists("assets/modules.json")
+    assetExists, err := util.PathExists(assetPath)
     util.FatalErr(err)
 
     if !assetExists {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title of this PR -->

## Description
<!--- Please include a brief summary of the changes and related issue (if there's any). -->
Fix issue when windows can't find modules.json.

## Current situation
<!--- Describe the current situation. Explain current problems, if there are any. -->
Gohard can't find modules.json file due to the differences in path separators in linux and windows.

## Proposed solution
<!--- Provide an in detail summary of the changes or features from user's POV. -->
We'll use filepath.Join() which determines the path separator for each OS.

## Screenshots (if appropriate):
<!--- Paste your screenshots below this line. -->
No screenshots needed.