### PR TITLE
Change the displaying of hardening modules in stdout

### DIFF
--- a/ui/interface.go
+++ b/ui/interface.go
@@ -24,8 +24,6 @@ func Run(modules []mods.Module) {
         os.Exit(1)
     }
 
-    fmt.Println("Type 'exit' to stop gohard")
-
     separator := strings.Repeat("-", 50)
     for idx, module := range modules {
         fmt.Println(separator)
@@ -34,7 +32,7 @@ func Run(modules []mods.Module) {
     }
 
     reader := bufio.NewReader(os.Stdin)
-    fmt.Printf("Enter module ID or interval: ")
+    fmt.Printf("Enter module ID or interval ('exit' to terminate gohard): ")
 
     userInput, _ := reader.ReadString('\n')
     userInput = strings.TrimSpace(userInput)

--- a/ui/interface.go
+++ b/ui/interface.go
@@ -26,13 +26,11 @@ func Run(modules []mods.Module) {
 
     fmt.Println("Type 'exit' to stop gohard")
 
-    separator := strings.Repeat("-", 80)
+    separator := strings.Repeat("-", 50)
     for idx, module := range modules {
         fmt.Println(separator)
-        fmt.Printf("Module ID -> %d\n", idx + 1)
-        fmt.Printf("Hardening module -> %s\n", module.Name)
-        fmt.Printf("Description -> %s\n", module.Description)
-        fmt.Printf("Command -> %s\n", module.Command)
+        fmt.Printf("Module ID: %d | %s\n", idx + 1, module.Name)
+        fmt.Printf("Description: %s\n", module.Description)
     }
 
     reader := bufio.NewReader(os.Stdin)

--- a/ui/interface.go
+++ b/ui/interface.go
@@ -26,7 +26,9 @@ func Run(modules []mods.Module) {
 
     separator := strings.Repeat("-", 50)
     for idx, module := range modules {
-        fmt.Println(separator)
+        if len(modules) > 1 {
+            fmt.Println(separator)
+        }
         fmt.Printf("Module ID: %d | %s\n", idx + 1, module.Name)
         fmt.Printf("Description: %s\n", module.Description)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title of this PR -->

## Description
<!--- Please include a brief summary of the changes and related issue (if there's any). -->
Make the output less cluttered.

## Current situation
<!--- Describe the current situation. Explain current problems, if there are any. -->
Currently the output is very messy, and it's really hard to look at.

## Proposed solution
<!--- Provide an in detail summary of the changes or features from user's POV. -->
Module ID and Module Name will be at the same line, followed by Description on newline. Command won't get printed out.
We'll use separator only if we have > 1 hardening modules.

## Screenshots (if appropriate):
<!--- Paste your screenshots below this line. -->
Will be uploaded to README.